### PR TITLE
fix: account for the View's scroll value in the previewBox calculation

### DIFF
--- a/plugin/src/main/java/com/android/tools/idea/editors/layoutInspectorv2/ui/ViewNodeActiveDisplay.java
+++ b/plugin/src/main/java/com/android/tools/idea/editors/layoutInspectorv2/ui/ViewNodeActiveDisplay.java
@@ -204,9 +204,12 @@ public class ViewNodeActiveDisplay extends JComponent {
       (int)(info.getHeight() * newScaleY * drawScale)
     );
 
+    float adjustedLeftShift = l - info.getScrollX() * newScaleX;
+    float adjustedTopShift = t - info.getScrollY() * newScaleY;
+
     if (!node.isLeaf()) {
       for (ViewNode child : node.getChildren()) {
-        calculateNodeBounds(child, child.displayInfo, l, t, newScaleX, newScaleY, drawScale);
+        calculateNodeBounds(child, child.displayInfo, adjustedLeftShift, adjustedTopShift, newScaleX, newScaleY, drawScale);
       }
     }
   }


### PR DESCRIPTION
Previously the previewBox calculation did not account for the View's scroll value which would lead to incorrect coordinate calculations in scenarios like ViewPager.